### PR TITLE
Fix a possible typo

### DIFF
--- a/Program/Params.cpp
+++ b/Program/Params.cpp
@@ -30,7 +30,7 @@ Params::Params(
 	ran.seed(ap.seed);
 
 	// check if valid coordinates are provided
-	areCoordinatesProvided = (demands.size() == x_coords.size()) && (demands.size() == x_coords.size());
+	areCoordinatesProvided = (demands.size() == x_coords.size()) && (demands.size() == y_coords.size());
 
 	cli = std::vector<Client>(nbClients + 1);
 	for (int i = 0; i <= nbClients; i++)


### PR DESCRIPTION
Hi, I noticed a possible issue while working on a Rust solver based on HGS-CVRP:

- there seems to be a typo: `areCoordinatesProvided` is currently initialized using `x_coords` (twice), but not using `y_coords`.

I'd actually consider getting rid of `areCoordinatesProvided` and modifying `AlgorithmParameters.useSwapStar` in place of the current initialization (as these attributes seem to be only used together and the former has a direct influence over the latter). However, there might be some reasons to use `areCoordinatesProvided`  that are unseen to me as I don't have much experience with C-portable C++.

*Question: Is there actually a case when coordinates are not provided and it is still desired to run the solver?*