### PR TITLE
Patches for Windows users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ set(
         Program/AlgorithmParameters.cpp
         Program/C_Interface.cpp)
 
+if (MSVC)
+	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif (MSVC)
+
 include_directories(Program)
 
 # Build Executable

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Build with:
 ```console
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
 make bin
 ```
 This will generate the executable file `hgs` in the `build` directory.
@@ -115,7 +115,7 @@ You can also build a shared library to call the HGS-CVRP algorithm from your cod
 ```console
 mkdir build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
 make lib
 ```
 This will generate the library file, `libhgscvrp.so` (Linux), `libhgscvrp.dylib` (macOS), or `hgscvrp.dll` (Windows),

--- a/Test/Test-c/test.c
+++ b/Test/Test-c/test.c
@@ -69,7 +69,7 @@ int main()
 	////////////////////////////////////////////////////////////////////////////////////////////////////////
 	printf("-------- test.c #2 -----\n");
 	// Test #2: solve by dist_mtx
-	double dist_mtx[n][n];
+	double dist_mtx[10][10];
 	for (int i=0; i < n; i++) {
 		for (int j=0; j< n; j++) {
 			dist_mtx[i][j] = sqrt( (x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]));
@@ -153,7 +153,7 @@ int main()
 
 	printf("-------- test.c #7 (tight duration constraint) -----\n");
 
-	double rounded_dist_mtx[n][n];
+	double rounded_dist_mtx[10][10];
 	for (int i=0; i < n; i++) {
 		for (int j=0; j< n; j++) {
 			rounded_dist_mtx[i][j] = sqrt( (x[i] - x[j]) * (x[i] - x[j]) + (y[i] - y[j]) * (y[i] - y[j]));


### PR DESCRIPTION
1. Update `README.md`:
In Github workflow [file](https://github.com/vidalt/HGS-CVRP/actions/runs/2437077405/workflow), it defaults to cmake with `-G "Unix Makefiles"` option. 
This option is critical for Windows mingw64 users since cmake in windows (msys2 mingw64) does not generate Makefile without the "Unix Makefiles" option.  
In my case, I also needed to add `-DCMAKE_MAKE_PROGRAM=X:/Path/To/Make` option for cmake command to fix ``CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.`` 

2. Fix [test code](https://github.com/th-yoon/HGS-CVRP/blob/main/Test/Test-c/test.c):
Since MSVC does not support variable-length arrays (VLA), the `dist_mtx` declaration is changed into a fixed-size array. This looks a bit ugly, but I guess it's ok for the test code(?)

3.   Fix [CMakeLists](https://github.com/vidalt/HGS-CVRP/blob/main/CMakeLists.txt):
MSVC does not generate a static library (`.lib`) for cmake's shared library declaration. A hotfix is to export all symbols if the compiler is MSVC.   