### PR TITLE
Uses msvc for windows test actions

### DIFF
--- a/.github/workflows/CI_Build.yml
+++ b/.github/workflows/CI_Build.yml
@@ -15,12 +15,19 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
+    - uses: ilammy/msvc-dev-cmd@v1
     - name: make bin on ${{ matrix.os }}
       run: | 
         mkdir build 
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
-        make bin
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          cmake .. -DCMAKE_BUILD_TYPE=Release -G "NMake Makefiles"
+          nmake bin
+        else
+          cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
+          make bin
+        fi
+      shell: bash
     - name: test bin on ${{ matrix.os }}
       run: |
         cd build
@@ -28,11 +35,23 @@ jobs:
     - name: make lib on ${{ matrix.os }}
       run: |
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
-        make lib
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          cmake .. -DCMAKE_BUILD_TYPE=Release -G "NMake Makefiles"
+          nmake lib
+        else
+          cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
+          make lib
+        fi
+      shell: bash
     - name: test lib on ${{ matrix.os }}
       run: |
         cd build
-        cmake .. -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles"        
-        make lib_test_c
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -G "NMake Makefiles"
+          nmake lib_test_c
+        else
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles"
+          make lib_test_c
+        fi  
         ctest -R lib --verbose
+      shell: bash


### PR DESCRIPTION
As discussed with @vidalt , it's better to use native compiler such as MSVC instead of MinGW for windows, as MinGW project is much more bug prone than GCC on linux.
Repo https://github.com/ilammy/msvc-dev-cmd seems to be trustworthy, and any issue in tests will not cause any security issue.. but it's also possible for @vidalt to fork it and we use this forked link here... but important updates may be missed, so I think it's fine to just use ilammy/msvc-dev-cmd 

Fixes https://github.com/vidalt/HGS-CVRP/issues/33
Closes https://github.com/vidalt/HGS-CVRP/issues/33