### PR TITLE
Change CMakeLists.txt to make it easier to import the library from other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,68 +20,66 @@ endif (MSVC)
 
 include_directories(Program)
 
-
-# Build Library
-
 # object to be used by both static and shared (compile only once)
 add_library(objlib OBJECT ${src_files})
 set_property(TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
-
-# static library
-add_library(lib_static STATIC $<TARGET_OBJECTS:objlib>)
-# if static and runtime libraries use name "hgscvrp", MSVC will overwrite one
-# of them, because both STATIC and SHARED builds create "hgscvrp.lib"
-set_target_properties(lib_static PROPERTIES OUTPUT_NAME hgscvrp_static)
 
 # runtime library
 add_library(lib SHARED $<TARGET_OBJECTS:objlib>)
 set_target_properties(lib PROPERTIES OUTPUT_NAME hgscvrp)
 
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # We're in the root, build everything
+    # static library
+    add_library(lib_static STATIC $<TARGET_OBJECTS:objlib>)
+    # if static and runtime libraries use name "hgscvrp", MSVC will overwrite one
+    # of them, because both STATIC and SHARED builds create "hgscvrp.lib"
+    set_target_properties(lib_static PROPERTIES OUTPUT_NAME hgscvrp_static)
 
-# Build Executable
+    # Build Executable
 
-add_executable(bin Program/main.cpp)
-target_link_libraries(bin PRIVATE lib_static)
-set_target_properties(bin PROPERTIES OUTPUT_NAME hgs)
-
-
-# Test Executable
-
-include(CTest)
-add_test(NAME    bin_test_X-n101-k25
-         COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n101-k25
-                                    -DCOST=27591
-                                    -DROUND=1
-                                    -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
-add_test(NAME    bin_test_X-n106-k14
-         COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n110-k13
-                                    -DCOST=14971
-                                    -DROUND=1
-                                    -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
-
-# Test Executable: Instances with Duration, without Rounding
-add_test(NAME    bin_test_CMT6
-        COMMAND ${CMAKE_COMMAND}    -DINSTANCE=CMT6
-                                    -DCOST=555.43
-                                    -DROUND=0
-                                    -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
-add_test(NAME    bin_test_CMT7
-        COMMAND ${CMAKE_COMMAND}    -DINSTANCE=CMT7
-                                    -DCOST=909.675
-                                    -DROUND=0
-                                    -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
+    add_executable(bin Program/main.cpp)
+    target_link_libraries(bin PRIVATE lib_static)
+    set_target_properties(bin PROPERTIES OUTPUT_NAME hgs)
 
 
-# Test Library
-add_subdirectory(Test/Test-c/)
-add_test(NAME       lib_test_c
-         COMMAND    lib_test_c)
+    # Test Executable
 
+    include(CTest)
+    add_test(NAME    bin_test_X-n101-k25
+             COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n101-k25
+                                        -DCOST=27591
+                                        -DROUND=1
+                                        -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
+    add_test(NAME    bin_test_X-n106-k14
+             COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n110-k13
+                                        -DCOST=14971
+                                        -DROUND=1
+                                        -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
 
-# Install
-install(TARGETS lib
-        DESTINATION lib)
-install(TARGETS bin
-        DESTINATION bin)
-install(FILES Program/AlgorithmParameters.h Program/C_Interface.h
-        DESTINATION include)
+    # Test Executable: Instances with Duration, without Rounding
+    add_test(NAME    bin_test_CMT6
+            COMMAND ${CMAKE_COMMAND}    -DINSTANCE=CMT6
+                                        -DCOST=555.43
+                                        -DROUND=0
+                                        -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
+    add_test(NAME    bin_test_CMT7
+            COMMAND ${CMAKE_COMMAND}    -DINSTANCE=CMT7
+                                        -DCOST=909.675
+                                        -DROUND=0
+                                        -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
+
+    # Test Library
+    add_subdirectory(Test/Test-c/)
+    add_test(NAME       lib_test_c
+             COMMAND    lib_test_c)
+
+    # Install
+    install(TARGETS lib
+            DESTINATION lib)
+    install(TARGETS bin
+            DESTINATION bin)
+    install(FILES Program/AlgorithmParameters.h Program/C_Interface.h
+            DESTINATION include)
+endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,33 @@ endif (MSVC)
 
 include_directories(Program)
 
-# Build Executable
-add_executable(bin
-        Program/main.cpp
-        ${src_files})
 
+# Build Library
+
+# object to be used by both static and shared (compile only once)
+add_library(objlib OBJECT ${src_files})
+set_property(TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+# static library
+add_library(lib_static STATIC $<TARGET_OBJECTS:objlib>)
+# if static and runtime libraries use name "hgscvrp", MSVC will overwrite one
+# of them, because both STATIC and SHARED builds create "hgscvrp.lib"
+set_target_properties(lib_static PROPERTIES OUTPUT_NAME hgscvrp_static)
+
+# runtime library
+add_library(lib SHARED $<TARGET_OBJECTS:objlib>)
+set_target_properties(lib PROPERTIES OUTPUT_NAME hgscvrp)
+
+
+# Build Executable
+
+add_executable(bin Program/main.cpp)
+target_link_libraries(bin PRIVATE lib_static)
 set_target_properties(bin PROPERTIES OUTPUT_NAME hgs)
 
+
 # Test Executable
+
 include(CTest)
 add_test(NAME    bin_test_X-n101-k25
          COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n101-k25
@@ -52,14 +71,12 @@ add_test(NAME    bin_test_CMT7
                                     -DROUND=0
                                     -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
 
-# Build Library
-add_library(lib SHARED ${src_files})
-set_target_properties(lib PROPERTIES OUTPUT_NAME hgscvrp)
 
 # Test Library
 add_subdirectory(Test/Test-c/)
 add_test(NAME       lib_test_c
          COMMAND    lib_test_c)
+
 
 # Install
 install(TARGETS lib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,24 +33,24 @@ add_test(NAME    bin_test_X-n101-k25
          COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n101-k25
                                     -DCOST=27591
                                     -DROUND=1
-                                    -P ${CMAKE_CURRENT_SOURCE_DIR}/Test/TestExecutable.cmake)
+                                    -P ${HGS_CVRP_SOURCE_DIR}/Test/TestExecutable.cmake)
 add_test(NAME    bin_test_X-n106-k14
          COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n110-k13
                                     -DCOST=14971
                                     -DROUND=1
-                                    -P ${CMAKE_CURRENT_SOURCE_DIR}/Test/TestExecutable.cmake)
+                                    -P ${HGS_CVRP_SOURCE_DIR}/Test/TestExecutable.cmake)
 
 # Test Executable: Instances with Duration, without Rounding
 add_test(NAME    bin_test_CMT6
         COMMAND ${CMAKE_COMMAND}    -DINSTANCE=CMT6
                                     -DCOST=555.43
                                     -DROUND=0
-                                    -P ${CMAKE_CURRENT_SOURCE_DIR}/Test/TestExecutable.cmake)
+                                    -P ${HGS_CVRP_SOURCE_DIR}/Test/TestExecutable.cmake)
 add_test(NAME    bin_test_CMT7
         COMMAND ${CMAKE_COMMAND}    -DINSTANCE=CMT7
                                     -DCOST=909.675
                                     -DROUND=0
-                                    -P ${CMAKE_CURRENT_SOURCE_DIR}/Test/TestExecutable.cmake)
+                                    -P ${HGS_CVRP_SOURCE_DIR}/Test/TestExecutable.cmake)
 
 # Build Library
 add_library(lib SHARED ${src_files})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,24 +33,24 @@ add_test(NAME    bin_test_X-n101-k25
          COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n101-k25
                                     -DCOST=27591
                                     -DROUND=1
-                                    -P ${HGS_CVRP_SOURCE_DIR}/Test/TestExecutable.cmake)
+                                    -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
 add_test(NAME    bin_test_X-n106-k14
          COMMAND ${CMAKE_COMMAND}   -DINSTANCE=X-n110-k13
                                     -DCOST=14971
                                     -DROUND=1
-                                    -P ${HGS_CVRP_SOURCE_DIR}/Test/TestExecutable.cmake)
+                                    -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
 
 # Test Executable: Instances with Duration, without Rounding
 add_test(NAME    bin_test_CMT6
         COMMAND ${CMAKE_COMMAND}    -DINSTANCE=CMT6
                                     -DCOST=555.43
                                     -DROUND=0
-                                    -P ${HGS_CVRP_SOURCE_DIR}/Test/TestExecutable.cmake)
+                                    -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
 add_test(NAME    bin_test_CMT7
         COMMAND ${CMAKE_COMMAND}    -DINSTANCE=CMT7
                                     -DCOST=909.675
                                     -DROUND=0
-                                    -P ${HGS_CVRP_SOURCE_DIR}/Test/TestExecutable.cmake)
+                                    -P ${PROJECT_SOURCE_DIR}/Test/TestExecutable.cmake)
 
 # Build Library
 add_library(lib SHARED ${src_files})

--- a/Test/Test-c/CMakeLists.txt
+++ b/Test/Test-c/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 3.15)
 project(HGS_Test_c)
 set(CMAKE_C_STANDARD 99)
 
-include_directories(${CMAKE_SOURCE_DIR}/Program)
+include_directories(${HGS_CVRP_SOURCE_DIR}/Program)
 
 add_executable(lib_test_c
         test.c
-        ${CMAKE_SOURCE_DIR}/Program/C_Interface.h
-        ${CMAKE_SOURCE_DIR}/Program/AlgorithmParameters.h
+        ${HGS_CVRP_SOURCE_DIR}/Program/C_Interface.h
+        ${HGS_CVRP_SOURCE_DIR}/Program/AlgorithmParameters.h
         )
 
 target_link_libraries(lib_test_c -lm lib)  # need -lm to link math library

--- a/Test/Test-c/CMakeLists.txt
+++ b/Test/Test-c/CMakeLists.txt
@@ -6,8 +6,8 @@ include_directories(${HGS_CVRP_SOURCE_DIR}/Program)
 
 add_executable(lib_test_c
         test.c
-        ${HGS_CVRP_SOURCE_DIR}/Program/C_Interface.h
-        ${HGS_CVRP_SOURCE_DIR}/Program/AlgorithmParameters.h
+        ${PROJECT_SOURCE_DIR}/Program/C_Interface.h
+        ${PROJECT_SOURCE_DIR}/Program/AlgorithmParameters.h
         )
 
 target_link_libraries(lib_test_c -lm lib)  # need -lm to link math library

--- a/Test/Test-c/CMakeLists.txt
+++ b/Test/Test-c/CMakeLists.txt
@@ -2,13 +2,10 @@ cmake_minimum_required(VERSION 3.15)
 project(HGS_Test_c)
 set(CMAKE_C_STANDARD 99)
 
-include_directories(${HGS_CVRP_SOURCE_DIR}/Program)
+add_executable(lib_test_c test.c)
 
-add_executable(lib_test_c
-        test.c
-        ${PROJECT_SOURCE_DIR}/Program/C_Interface.h
-        ${PROJECT_SOURCE_DIR}/Program/AlgorithmParameters.h
-        )
-
-target_link_libraries(lib_test_c -lm lib)  # need -lm to link math library
+IF (NOT WIN32)
+  target_link_libraries(lib_test_c m)
+ENDIF()
+target_link_libraries(lib_test_c lib_static)
 


### PR DESCRIPTION
This PR is motivated by issue https://github.com/chkwon/PyHygese/issues/30. There is a quick-fix PR in https://github.com/chkwon/PyHygese/pull/31, but a more robust fix needs the changes proposed here to HGS-CVRP's build recipe.

The corresponding PR to PyHygese is https://github.com/chkwon/PyHygese/pull/32 (which will be updated to the official HGS-CVRP repo if this PR is merged).

The changes proposed here should produce the same output as previously, with the advantage of not compiling two times the library objects.